### PR TITLE
cudaPointerGetAttribute changes return value in CUDA11

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -7,7 +7,7 @@ from io import StringIO
 
 class RingbufferConan(ConanFile):
     name = "ringbuffer"
-    version = "0.2.3"
+    version = "0.2.4"
 
     description = "Ringbuffer Library"
     url = "https://github.com/TUM-CAMP-NARVIS/ringbuffer"

--- a/src/detail/memory.cpp
+++ b/src/detail/memory.cpp
@@ -81,6 +81,11 @@ namespace ringbuffer {
                     case cudaMemoryTypeDevice:
                         *space = RBSpace::SPACE_CUDA;
                         break;
+#if CUDART_VERSION >= 1100
+                    case cudaMemoryTypeUnregistered:
+                        *space = RBSpace::SPACE_SYSTEM;
+                        break;
+#endif
                     default: {
                         // This should never be reached - unless someone uses SHM Space which is not yet implemented ...
                         RB_FAIL("Valid memoryType", RBStatus::STATUS_INTERNAL_ERROR);


### PR DESCRIPTION
fix for a breaking unit-test in CUDA 11: the return value of cudaPointerGetAttribute changed to return cudaSucess and cudaMemoryTypeUnregistered: [https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__UNIFIED.html](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__UNIFIED.html)