### PR TITLE
Do not acquire spans with already overwritten data

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -7,7 +7,7 @@ from io import StringIO
 
 class RingbufferConan(ConanFile):
     name = "ringbuffer"
-    version = "0.2.4"
+    version = "0.2.5"
 
     description = "Ringbuffer Library"
     url = "https://github.com/TUM-CAMP-NARVIS/ringbuffer"

--- a/src/ring.cpp
+++ b/src/ring.cpp
@@ -523,7 +523,7 @@ namespace ringbuffer {
         auto& state = get_state();
         state::unique_lock_type lock(state.mutex);
         SequencePtr sequence = this->_get_sequence_at(time_tag);
-        if(sequence->begin() >= state.tail) {
+        if(sequence->begin() < state.tail) {
             //This sequence was already overwritten
             return nullptr;
         }

--- a/src/ring.cpp
+++ b/src/ring.cpp
@@ -523,6 +523,10 @@ namespace ringbuffer {
         auto& state = get_state();
         state::unique_lock_type lock(state.mutex);
         SequencePtr sequence = this->_get_sequence_at(time_tag);
+        if(sequence->begin() >= state.tail) {
+            //This sequence was already overwritten
+            return nullptr;
+        }
         if( scoped_guarantee ) {
             // Move guarantee to start of sequence
             scoped_guarantee->move_nolock(

--- a/src/sequence.cpp
+++ b/src/sequence.cpp
@@ -113,6 +113,9 @@ namespace ringbuffer {
     std::unique_ptr<ReadSequence> ReadSequence::at_ptr(const std::shared_ptr<Ring>& ring, time_tag_type time_tag, bool with_guarantee) {
         std::unique_ptr<state::Guarantee> guarantee;
         SequencePtr sequence = ring->open_sequence_at(time_tag, with_guarantee, guarantee);
+        if(!sequence){
+            return nullptr;
+        }
         return std::unique_ptr<ReadSequence>(new ReadSequence(sequence, guarantee));
     }
 

--- a/src/sequence.cpp
+++ b/src/sequence.cpp
@@ -113,9 +113,6 @@ namespace ringbuffer {
     std::unique_ptr<ReadSequence> ReadSequence::at_ptr(const std::shared_ptr<Ring>& ring, time_tag_type time_tag, bool with_guarantee) {
         std::unique_ptr<state::Guarantee> guarantee;
         SequencePtr sequence = ring->open_sequence_at(time_tag, with_guarantee, guarantee);
-        if(!sequence){
-            return nullptr;
-        }
         return std::unique_ptr<ReadSequence>(new ReadSequence(sequence, guarantee));
     }
 


### PR DESCRIPTION
Related to https://github.com/TUM-CAMP-NARVIS/pcpd/issues/89

Since acuiqre_span does not have a return code, the obvious solution is an exception: if the requested memory region is behind the tail, we should not pass it along to the library user because it contains overwritten data.

Includes:
- throw an exception to report already overwritten spans to the user
- version bump to 0.2.5