### PR TITLE
Fix for cycling shared_ptr references

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -7,7 +7,7 @@ from io import StringIO
 
 class RingbufferConan(ConanFile):
     name = "ringbuffer"
-    version = "0.2.5"
+    version = "0.2.6"
 
     description = "Ringbuffer Library"
     url = "https://github.com/TUM-CAMP-NARVIS/ringbuffer"

--- a/include/ringbuffer/common.h
+++ b/include/ringbuffer/common.h
@@ -80,6 +80,7 @@ namespace ringbuffer {
         STATUS_FAILED_TO_CONVERGE                       = 64,
         STATUS_INSUFFICIENT_STORAGE                     = 65,
         STATUS_DEVICE_ERROR                             = 66,
+        STATUS_RING_NOT_AVAILABLE                       = 67,
         STATUS_INTERNAL_ERROR                           = 99
     };
 

--- a/include/ringbuffer/sequence.h
+++ b/include/ringbuffer/sequence.h
@@ -58,7 +58,7 @@ namespace ringbuffer {
     class RINGBUFFER_EXPORT Sequence {
         friend class Ring;
         enum { RF_SEQUENCE_OPEN = (std::size_t)-1 };
-        std::shared_ptr<Ring> m_ring;
+        std::weak_ptr<Ring> m_ring;
         std::string    m_name;
         time_tag_type  m_time_tag;
         std::size_t    m_nringlet;
@@ -70,7 +70,7 @@ namespace ringbuffer {
         std::size_t    m_readrefcount; // ever used ??
 
     public:
-        Sequence(const std::shared_ptr<Ring>&  ring,
+        Sequence(const std::weak_ptr<Ring>&  ring,
                  std::string   name,
                  time_tag_type time_tag,
                  std::size_t   header_size,
@@ -90,7 +90,7 @@ namespace ringbuffer {
         void set_next(SequencePtr next);
 
         inline bool          is_finished() const { return m_end != RF_SEQUENCE_OPEN; }
-        inline std::shared_ptr<Ring> ring() { return m_ring; }
+        inline std::weak_ptr<Ring> ring() { return m_ring;}
         inline std::string   name()        const { return m_name; }
         inline time_tag_type time_tag()    const { return m_time_tag; }
         inline const void*   header()      const { return m_header.size() ? &m_header[0] : nullptr; }
@@ -117,7 +117,7 @@ namespace ringbuffer {
 
 		inline SequencePtr   sequence()    const { return m_sequence; }
         inline bool          is_finished() const { return m_sequence->is_finished(); }
-        inline std::shared_ptr<Ring> ring() { return m_sequence->ring(); }
+        inline std::weak_ptr<Ring> ring() { return m_sequence->ring(); }
         inline std::string   name()        const { return m_sequence->name(); }
         inline time_tag_type time_tag()    const { return m_sequence->time_tag(); }
         inline const void*   header()      const { return m_sequence->header(); }
@@ -162,7 +162,7 @@ namespace ringbuffer {
         WriteSequence(WriteSequence&& )                 = delete;
         WriteSequence& operator=(WriteSequence&& )      = delete;
 
-        WriteSequence(const std::shared_ptr<Ring>& ring, const std::string& name,
+        WriteSequence(const std::weak_ptr<Ring>& ring, const std::string& name,
                       time_tag_type time_tag, std::size_t header_size,
                       const void* header, std::size_t nringlet,
                       std::size_t offset_from_head=0);

--- a/include/ringbuffer/span.h
+++ b/include/ringbuffer/span.h
@@ -55,7 +55,7 @@
 namespace ringbuffer {
 
     class RINGBUFFER_EXPORT Span {
-        std::shared_ptr<Ring> m_ring;
+        std::weak_ptr<Ring> m_ring;
         std::size_t  m_size;
 
     protected:
@@ -69,10 +69,10 @@ namespace ringbuffer {
         Span(Span&& )                 = delete;
         Span& operator=(Span&& )      = delete;
 
-        Span(const std::shared_ptr<Ring>& ring, std::size_t size);
+        Span(const std::weak_ptr<Ring>& ring, std::size_t size);
         virtual ~Span();
 
-        std::shared_ptr<Ring> ring() const;
+        std::weak_ptr<Ring> ring() const;
         std::size_t     size() const;
         // Note: These two are only safe to read while a span is open (preventing resize)
         std::size_t     stride() const;
@@ -94,7 +94,7 @@ namespace ringbuffer {
         WriteSpan(WriteSpan&& )                 = delete;
         WriteSpan& operator=(WriteSpan&& )      = delete;
 
-        WriteSpan(const std::shared_ptr<Ring>& ring, std::size_t size, bool nonblocking, std::chrono::nanoseconds timeout=std::chrono::nanoseconds(0));
+        WriteSpan(const std::weak_ptr<Ring>& ring, std::size_t size, bool nonblocking, std::chrono::nanoseconds timeout=std::chrono::nanoseconds(0));
         ~WriteSpan() override;
 
         WriteSpan* commit(std::size_t size);


### PR DESCRIPTION
See https://github.com/TUM-CAMP-NARVIS/pcpd/issues/83
- fix for a shared_ptr cycle: sequence is owning a shared_ptr to ring, while ring holds all sequences also via shared_ptr. break up the cycle by changing sequence/span to hold a weak_ptr otherwise. If the underlying ringbuffer of a sequence or span was already deallocated, an exception will be thrown.
- bump version to 0.2.6